### PR TITLE
Add option to show used history message under the prompt without creating a new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Configuration
   should be set to something that's unlikely to occur as a path
   component in any paths you intend to visit on your filesystem.
 
+* `PER_DIRECTORY_HISTORY_NEW_PROMPT` is a shell variable which defines if
+  new prompt is created when the history is toggled. Set to false to only
+  show a message below the prompt.
+
 * `per-directory-history-toggle-history` is the function to toggle the
   history mode.
 

--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -6,22 +6,35 @@
 [[ -z $PER_DIRECTORY_HISTORY_BASE ]] && PER_DIRECTORY_HISTORY_BASE="$HOME/.zsh_history_dirs"
 [[ -z $PER_DIRECTORY_HISTORY_FILE ]] && PER_DIRECTORY_HISTORY_FILE="zsh-per-directory-history"
 [[ -z $PER_DIRECTORY_HISTORY_TOGGLE ]] && PER_DIRECTORY_HISTORY_TOGGLE='\el'
+[[ -z $PER_DIRECTORY_HISTORY_NEW_PROMPT ]] && PER_DIRECTORY_HISTORY_NEW_PROMPT=true
 
 #-------------------------------------------------------------------------------
 # toggle global/directory history used for searching - alt-l by default
 #-------------------------------------------------------------------------------
 
 function per-directory-history-toggle-history() {
+	local message
+
 	if $_per_directory_history_is_global
 	then
 		_per-directory-history-set-directory-history
-		print -n "\e[2K\rusing local history\n"
+		message="using local history"
 	else
 		_per-directory-history-set-global-history
-		print -n "\e[2K\rusing global history\n"
+		message="using global history"
 	fi
-	zle .push-line
-	zle .accept-line
+
+	if $PER_DIRECTORY_HISTORY_NEW_PROMPT
+	then
+		print -n "\e[2K\r$message\n"
+		zle .push-line
+		zle .accept-line
+	elif zle
+	then
+		zle -Rc "" $message
+	else
+		echo $message
+	fi
 }
 
 autoload per-directory-history-toggle-history

--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -47,12 +47,16 @@ bindkey $PER_DIRECTORY_HISTORY_TOGGLE per-directory-history-toggle-history
 
 _per_directory_history_path="$PER_DIRECTORY_HISTORY_BASE${PWD:A}/$PER_DIRECTORY_HISTORY_FILE"
 
+function _per-directory-history-ensure-path() {
+	[ -d ${_per_directory_history_path:h} ] || mkdir -p ${_per_directory_history_path:h}
+}
+
 function _per-directory-history-change-directory() {
 	_per_directory_history_path="$PER_DIRECTORY_HISTORY_BASE${PWD:A}/$PER_DIRECTORY_HISTORY_FILE"
 	if ! $_per_directory_history_is_global
 	then
 		fc -P
-		mkdir -p ${_per_directory_history_path:h}
+		_per-directory-history-ensure-path
 		fc -p $_per_directory_history_path
 	fi
 }
@@ -79,7 +83,7 @@ function _per-directory-history-preexec() {
 			local fn
 			if $_per_directory_history_is_global
 			then
-				mkdir -p ${_per_directory_history_path:h}
+				_per-directory-history-ensure-path
 				fn=$_per_directory_history_path
 			else
 				fn=$_per_directory_history_main_histfile
@@ -102,7 +106,7 @@ function _per-directory-history-preexec() {
 function _per-directory-history-set-directory-history() {
 	fc -P
 
-	[ -d ${_per_directory_history_path:h} ] || mkdir -p ${_per_directory_history_path:h}
+	_per-directory-history-ensure-path
 	fc -p $_per_directory_history_path
 	_per_directory_history_is_global=false
 }

--- a/per-directory-history.zsh
+++ b/per-directory-history.zsh
@@ -102,7 +102,7 @@ function _per-directory-history-preexec() {
 function _per-directory-history-set-directory-history() {
 	fc -P
 
-	mkdir -p ${_per_directory_history_path:h}
+	[ -d ${_per_directory_history_path:h} ] || mkdir -p ${_per_directory_history_path:h}
 	fc -p $_per_directory_history_path
 	_per_directory_history_is_global=false
 }


### PR DESCRIPTION
I preferred the way [zsh-cwd-history](https://github.com/ericfreese/zsh-cwd-history ) showed the toggle message and did not create a new prompt for each toggle.

I've added this behavior as an opt-in using `PER_DIRECTORY_HISTORY_NEW_PROMPT`.
If you don't change the variable nothing changes.